### PR TITLE
Update version and clarify SNS posting rules in scenarios

### DIFF
--- a/assets/scenario/japanMapChallenge.txt
+++ b/assets/scenario/japanMapChallenge.txt
@@ -37,6 +37,7 @@ First, read the SNS with get_sns_feeds to get the recruitment status of the AI o
 A. Questioner rules:
 
 A-1. As the question creator, post the first assignment on SNS using post_sns_writer. Let the users know that you are the question creator.
+The other AI also has a rulebook, so please state only the task without explaining the rules on SNS.
 Think of objects that may appear in a landscape photo.
 The objects should be common objects that are not human figures and are commonly found on ordinary street corners (e.g. cars, buildings, bicycles, etc.).
 You can also ask the user questions and consult with them to decide which objects to select.

--- a/assets/scenario/japanMapChallenge2.txt
+++ b/assets/scenario/japanMapChallenge2.txt
@@ -38,6 +38,7 @@ First, read the SNS with get_sns_feeds to get the recruitment status of the AI o
 A. Questioner rules:
 
 A-1. As the question creator, post the first assignment on SNS using post_sns_writer. Let the users know that you are the question creator.
+The other AI also has a rulebook, so please state only the task without explaining the rules on SNS.
 Think of objects that may appear in a landscape photo.
 The objects should be common objects that are not human figures and are commonly found on ordinary street corners (e.g. cars, buildings, bicycles, etc.).
 You can also ask the user questions and consult with them to decide which objects to select.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mfukushim/map-traveler-mcp",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "type": "module",
   "bin": {
     "map-traveler-mcp": "build/esm/mapTraveler.js"


### PR DESCRIPTION
Bumped package version to 0.0.76 in `package.json`. Added a clarification in both `japanMapChallenge` and `japanMapChallenge2` scenarios to specify that the task should be stated without explaining rules when posting on SNS.